### PR TITLE
fix sync script

### DIFF
--- a/sync_with_linux.sh
+++ b/sync_with_linux.sh
@@ -8,10 +8,15 @@ function usage()
 
 if [ ! -d "$1" ];
 then
-  usage $0
+  LINUX_SRC="/usr/src/linux-headers-$(uname -r)"
+  if [ ! -d "$LINUX_SRC" ];
+  then
+    usage $0
+    else
+  echo "sync with $LINUX_SRC"
+  fi
 fi
 
-LINUX_SRC="$1"
 DST="."
 
 rm -rf ${DST}/fixdep


### PR DESCRIPTION
if user doesn't provide <path-to-linux-kernel> than try to use default path "/usr/src/linux-headers-$(uname -r)". If there is no default path then exit with msg

before this commit you should did `u@user:~/kbuild-standalone_readme$ ./sync_with_linux.sh /usr/src/linux-headers-$(uname -r)`